### PR TITLE
ci: use PAT token for release workflow to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Verify branch
         run: |


### PR DESCRIPTION
## Summary
- Update release workflow to use PAT_TOKEN instead of GITHUB_TOKEN
- Allows workflow to bypass branch protection rules when pushing version bumps and tags to main
- Resolves GH013 repository rule violations error

## Changes
- Modified [.github/workflows/release.yml](.github/workflows/release.yml) to use secrets.PAT_TOKEN for checkout step

## Prerequisites
- PAT_TOKEN secret must be configured in repository secrets
- 'Write' role must be added to bypass list in branch protection ruleset

## Testing
- Release workflow can now successfully push to main branch